### PR TITLE
`v1.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### 🧰 Maintenance
 
+* Update [Scala](https://scala-lang.org/) version to `3.0.2` (was `3.0.1`)
 * Update [MUnit](https://github.com/scalameta/munit) version to `0.7.29` (was `0.7.28`)
 * Update [scalafmt](https://github.com/scalameta/scalafmt) version to `3.0.2` (was `3.0.1`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### 🧰 Maintenance
+
+* Update [MUnit](https://github.com/scalameta/munit) version to `0.7.29` (was `0.7.28`)
+
 ## [1.5.0]
 
 ### 🧰 Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### 🧰 Maintenance
 
 * Update [MUnit](https://github.com/scalameta/munit) version to `0.7.29` (was `0.7.28`)
+* Update [scalafmt](https://github.com/scalameta/scalafmt) version to `3.0.2` (was `3.0.1`)
 
 ## [1.5.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [1.5.1]
 
 ### 🧰 Maintenance
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sbt new file://../scala-lib.g8/
 
 3. Merge changes back into the main branch
 
-4. Tag version `git tag -a v1.5.0 -m "Release version 1.5.0."`
+4. Tag version `git tag -a v1.5.1 -m "Release version 1.5.1."`
 
 5. Publish the new release `git push --tags`
 

--- a/src/main/g8/.scalafmt.conf
+++ b/src/main/g8/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.0.1"
+version = "3.0.2"
 
 # https://scalameta.org/scalafmt/docs/configuration.html#scala3-rewrites
 runner.dialect = scala3

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / licenses := Seq("MIT License" -> url("https://opensource.org/licenses/MIT"))
 
-ThisBuild / scalaVersion := "3.0.1"
+ThisBuild / scalaVersion := "3.0.2"
 
 lazy val supportedScalaVersions = List("2.13.6", "3.0.1")
 ThisBuild / crossScalaVersions := supportedScalaVersions

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -27,6 +27,6 @@ lazy val lib = (project in file("lib"))
 
     libraryDependencies ++= Seq(
       // tests
-      "org.scalameta" %% "munit" % "0.7.28" % Test
+      "org.scalameta" %% "munit" % "0.7.29" % Test
     )
   )


### PR DESCRIPTION
## 🧰 Maintenance

* Update [Scala](https://scala-lang.org/) version to `3.0.2` (was `3.0.1`)
* Update [MUnit](https://github.com/scalameta/munit) version to `0.7.29` (was `0.7.28`)
* Update [scalafmt](https://github.com/scalameta/scalafmt) version to `3.0.2` (was `3.0.1`)
